### PR TITLE
Issue finder

### DIFF
--- a/issue_finder.py
+++ b/issue_finder.py
@@ -1,0 +1,62 @@
+from fnmatch import fnmatch
+from http.client import IncompleteRead
+import os
+import pathlib
+from urllib.error import HTTPError
+import urllib.request
+import yaml
+
+from issues.issues import Issues
+
+
+class IssuesFinder:
+    """Known OCP CI issues."""
+
+    def __init__(self):
+        self.issues_found = []
+        self.issues = Issues()
+        self.issue_yamls = self.read_issue_yaml()
+
+    def read_issue_yaml(self):
+        """Return a list of objects read in from issue yaml defs."""
+        issue_yamls = []
+        script_dir_path = pathlib.Path(__file__).parent.resolve()
+        for (dirpath, dirnames, filenames) in os.walk(
+            os.path.join(script_dir_path, "issues")
+        ):
+            for name in filenames:
+                if fnmatch(name, "issue_*.yaml"):
+                    yaml_path = os.path.join(dirpath, name)
+                    content = yaml.load(open(yaml_path), Loader=yaml.SafeLoader)
+                    issue_yamls.append(content)
+        return issue_yamls
+
+    def find_issues(self, logs):
+        """Returns a list of known issues found in the test logs."""
+        if logs is not None:
+            log_text = self.get_file_from_url(logs)
+            if log_text is not None:
+                for issue_def in self.issue_yamls:
+                    # This could take awhile.
+                    # Let the user know something is happening
+                    print(" .")
+                    if self.issues.search(log_text, issue_def):
+                        self.issues_found.append(issue_def["description"])
+        return self.issues_found
+
+    def get_file_from_url(self, url: str):
+        "Return file content downloaded from url."
+        # Try three times to help with intermittent connection issues.
+        for i in range(3):
+            content = None
+            try:
+                content = urllib.request.urlopen(url).read().decode("utf8")
+            except IncompleteRead:
+                print(f"Caught IncompleteRead in iteration {i}.")
+                continue
+            except HTTPError:
+                print(f"Skipping download due to HTTPError: {url}")
+                break
+            else:
+                break
+        return content

--- a/issues/issue_OCPQE_5204.yaml
+++ b/issues/issue_OCPQE_5204.yaml
@@ -1,0 +1,4 @@
+description: 'https://issues.redhat.com/browse/OCPQE-5204'
+match_ordered_strings:
+- 'Scenario: Etcd basic verification ==='
+- 'RuntimeError: See log, waiting for labeled pods futile: k8s-app=etcd'

--- a/issues/issue_OCPQE_5743.yaml
+++ b/issues/issue_OCPQE_5743.yaml
@@ -1,0 +1,5 @@
+description: 'https://issues.redhat.com/browse/OCPQE-5743'
+match_ordered_strings:
+- '=== After Scenario:'
+- 'the server is currently unable to handle the request \(get projects.project.openshift.io\)'
+- 'RuntimeError: error getting projects by user'

--- a/issues/issues.py
+++ b/issues/issues.py
@@ -1,0 +1,51 @@
+import re
+
+
+class Issues:
+    """Issues definitions."""
+
+    def match_ordered_strings(self, log: str, targets: list):
+        """Returns True if all the regex strings in targets are found in order."""
+        found_all = set()
+        last_match_line = 0
+        for target in targets:
+            line_count = 0
+            found = False
+            for line in log.splitlines():
+                if line_count < last_match_line:
+                    continue
+                line_count += 1
+                match = re.search(target, line)
+                if match:
+                    found = True
+                    break
+            found_all.add(found)
+        return all(found_all)
+
+    def get_method_refs(self, names):
+        """Return a dict of callable method refs, keyed by name in names."""
+        refs = dict()
+        for name in names:
+            if name == "description":
+                continue
+            refs[name] = getattr(self, name)
+        return refs
+
+    def search(self, log_text, issue_def):
+        """
+        Return True if log_text matches all the criteria in issue_def.
+
+        issue_def: A dict with keys that match method names defined in this
+            class.
+        description: issue_def.keys() is expected to be a list of method
+            names, that match up with methods defined in this class. Each
+            method is called with log_text and the coresponding issue_def
+            value as arguments. The issue_def value must contain all the
+            structured data that is required by the called method.
+        """
+
+        found_all = set()
+        method_refs = self.get_method_refs(issue_def.keys())
+        for name, ref in method_refs.items():
+            found_all.add(ref(log_text, issue_def[name]))
+        return all(found_all)

--- a/parse_ci_monitor_json.py
+++ b/parse_ci_monitor_json.py
@@ -6,9 +6,10 @@ import re
 import sys
 import os
 import subprocess
-import pprint
 from datetime import datetime
 from typing import List
+
+from issue_finder import IssuesFinder
 
 
 def argparser():
@@ -17,10 +18,10 @@ def argparser():
     )
 
     parser.add_argument(
-        "-f",
-        "--files",
+        "-r",
+        "--runs",
         nargs="+",
-        help="space seperated values of test run JSON files generated from ci_monitor tool",
+        help="space seperated list of test run ids.",
     )
     parser.add_argument(
         "-o",
@@ -28,14 +29,31 @@ def argparser():
         help="location to write output file",
         default=f"./{datetime.today().strftime('%Y%m%d')}.json",
     )
-    parser.add_argument("-v", "--version", help="Specify OCP version", required=True)
+    parser.add_argument(
+        "-i",
+        "--issues",
+        action="store_true",
+        help="Searching for known issues.",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="Specify OCP version",
+        required=True,
+    )
     return parser.parse_args()
 
 
-def get_test_failure_profile(content: str, profile: str):
+def get_link_to_log(content: str):
     content = re.search("(http.*)", content)
     if content:
-        linkto_logs = "[Link to logs|" + content.groups()[0] + "]|" + profile
+        return content.groups()[0]
+
+
+def get_test_failure_profile(content: str, profile: str):
+    content = get_link_to_log(content)
+    if content:
+        linkto_logs = "[Link to logs|" + content + "]|" + profile
     else:
         linkto_logs = f"not found|{profile}"
     return linkto_logs
@@ -67,6 +85,32 @@ def get_owner(ascript: str, testid: str):
     return owner
 
 
+def get_testrun_json(run_id: str):
+    """Download the test case json data from polarshift."""
+
+    # Call $BUSHSLICER_HOME/tools/polarshift.rb get-run RUN_ID to download the json describing the test run
+    BUSHSLICER_HOME = os.getenv("BUSHSLICER_HOME")
+    # use -o to avoid extra non json garbage printed to stdout
+    cmd = [
+        f"{BUSHSLICER_HOME}/tools/polarshift.rb",
+        "get-run",
+        f"{run_id}",
+        "-o",
+        f"{run_id}.json",
+    ]
+    subprocess.check_output(cmd)
+    run_json = get_json_from_file(f"{run_id}.json")
+    return run_json
+
+
+def get_json_from_file(file_path: str):
+    """Read in json from file_path."""
+
+    with open(file_path, "r") as f:
+        content = json.load(f)
+    return content
+
+
 def write_output(data: dict, ofile: str):
     with open(ofile, "w") as outfile:
         json.dump(data, outfile, indent=4, sort_keys=True)
@@ -74,40 +118,49 @@ def write_output(data: dict, ofile: str):
 
 def main():
     args = argparser()
-    logs_files = set(args.files)
     report_struct = {"version": args.version}
-    for file in logs_files:
-        with open(file) as fh:
-            output = json.load(fh)
-            profile = output["title"]
-            profile = re.search(".* - (.*)$", profile)
-            profile = profile.groups()[0]
-            for record in output["records"]["TestRecord"]:
-                if record["result"] == "Failed":
-                    linkto_logs = get_test_failure_profile(
-                        record["comment"]["content"], profile
-                    )
-                    automation_script = get_automation_script(
-                        record["test_case"]["customFields"]["Custom"]
-                    )
-                    id = record["test_case"]["id"]
-                    owner = get_owner(automation_script, id)
-                    if report_struct.get(owner, 0):
-                        if report_struct[owner].get(automation_script, 0):
-                            if report_struct[owner][automation_script].get(id, 0):
-                                report_struct[owner][automation_script][id].append(
-                                    linkto_logs
-                                )
-                            else:
-                                report_struct[owner][automation_script].update(
-                                    {id: [linkto_logs]}
-                                )
+    for run in args.runs:
+        output = get_testrun_json(run)
+        profile = output["title"]
+        profile = re.search(".* - (.*)$", profile)
+        profile = profile.groups()[0]
+        for record in output["records"]["TestRecord"]:
+            if record["result"] == "Failed":
+                linkto_logs = get_test_failure_profile(
+                    record["comment"]["content"], profile
+                )
+                automation_script = get_automation_script(
+                    record["test_case"]["customFields"]["Custom"]
+                )
+                id = record["test_case"]["id"]
+                owner = get_owner(automation_script, id)
+                if report_struct.get(owner, 0):
+                    if report_struct[owner].get(automation_script, 0):
+                        if report_struct[owner][automation_script].get(id, 0):
+                            report_struct[owner][automation_script][id].append(
+                                linkto_logs
+                            )
                         else:
-                            report_struct[owner].update(
-                                {automation_script: {id: [linkto_logs]}}
+                            report_struct[owner][automation_script].update(
+                                {id: [linkto_logs]}
                             )
                     else:
-                        report_struct[owner] = {automation_script: {id: [linkto_logs]}}
+                        report_struct[owner].update(
+                            {automation_script: {id: [linkto_logs]}}
+                        )
+                else:
+                    report_struct[owner] = {automation_script: {id: [linkto_logs]}}
+                # Find known issues
+                if args.issues:
+                    issue_finder = IssuesFinder()
+                    issues = issue_finder.find_issues(
+                        get_link_to_log(record["comment"]["content"])
+                    )
+                    if issues:
+                        print(f"Found issues for {id}: {issues}")
+                        report_struct[owner][automation_script][id].append(
+                            dict([("known_issues", issues)])
+                        )
 
     write_output(report_struct, args.output)
 


### PR DESCRIPTION
This PR adds a module to support searching for known issues in the given test run ID.
Example call and run output:
./parse_ci_monitor_json.py --runs 20210909-0851 -v 4.8 -i
.
 .
 .
 .
Found issues for OCP-12024: ['https://issues.redhat.com/browse/OCPQE-5204']
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
 .
Found issues for OCP-26040: ['https://issues.redhat.com/browse/OCPQE-5743']
 .
 .
 .
Found issues for OCP-12292: ['https://issues.redhat.com/browse/OCPQE-5743']
 .
 .
Found issues for OCP-43747: ['https://issues.redhat.com/browse/OCPQE-5743']

There is one search method named "match_ordered_strings" defined in this first iteration.
issue_OCPQE_5204.yaml and issue_OCPQE_5743.yaml are examples of how to describe an issue in a yaml definition file.
"description:" holds the string that will be printed if the issue is matched.
"match_ordered_strings:" holds a list of regex strings that will be passed to Issues.match_ordered_strings()

This module can be extended by adding additional methods to the Issues class and then adding an attribute to the yaml with a dict key that matches the method name. For example functionality might be added that checks to see if the tests were run on a particular cloud provider or if certain operators are installed. This may require getting access to additional log files or a must-gather. 

The -i option is required to trigger the search, as it can take some time to download each log file and run the search.

To become useful additional issue yaml files will need to be added to support discovery of more existing issues. Scripting identification of known issues can save time for those triaging failures and avoid opening duplicate bugs.